### PR TITLE
Kubernetes 1.26 update

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ For more info, refer to the Tanka tutorial at https://tanka.dev/tutorial/k-lib.
 #### Standalone
 
 ```bash
-$ jb install github.com/jsonnet-libs/k8s-libsonnet/1.25@main
+$ jb install github.com/jsonnet-libs/k8s-libsonnet/1.26@main
 ```
 
 Then import it in your project:
 
 ```jsonnet
-local k = import "github.com/jsonnet-libs/k8s-libsonnet/1.25/main.libsonnet"
+local k = import "github.com/jsonnet-libs/k8s-libsonnet/1.26/main.libsonnet"
 ```
 
 ## FAQ

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ The Jsonnet Kubernetes library is a generated with
 
 Currently, artifacts for the following Kubernetes versions are provided:
 
+- [v1.26](1.26/README.md)
 - [v1.25](1.25/README.md)
 - [v1.24](1.24/README.md)
 - [v1.23](1.23/README.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,6 +14,7 @@
       "minify_html": true
   - "exclude-search":
       "exclude":
+        - "1.25/*"
         - "1.24/*"
         - "1.23/*"
         - "1.22/*"


### PR DESCRIPTION
`mkdocs.yaml` and `README.md` ammends to match the skel and resolve the diff for the k8s-gen codegen tool.

![img](https://user-images.githubusercontent.com/6811933/212808575-1d4059b3-4f1e-4898-b18e-467044709c1b.png)
