### PR TITLE
Don't patch the `v1beta1` API version with CronJob patch.

### DIFF
--- a/1.25/_custom/batch.libsonnet
+++ b/1.25/_custom/batch.libsonnet
@@ -22,7 +22,6 @@ local patch = {
 {
   batch+: {
     v1+: patch,
-    v1beta1+: patch,
     v2alpha1+: patch,
   },
 }

--- a/1.26/_custom/batch.libsonnet
+++ b/1.26/_custom/batch.libsonnet
@@ -22,7 +22,6 @@ local patch = {
 {
   batch+: {
     v1+: patch,
-    v1beta1+: patch,
     v2alpha1+: patch,
   },
 }

--- a/1.27/_custom/batch.libsonnet
+++ b/1.27/_custom/batch.libsonnet
@@ -22,7 +22,6 @@ local patch = {
 {
   batch+: {
     v1+: patch,
-    v1beta1+: patch,
     v2alpha1+: patch,
   },
 }


### PR DESCRIPTION
The `v1beta1` API has removed the `v1beta1` `CronJob` and hence, it
doesn't make sense to apply the patch here. Since no other objects are
being patched in the code, this PR takes the easy route of just removing
the `v1beta` patch application.

Note that this is mostly a cosmetic change -- using the the `v1beta1`
`CronJob` with 1.25+ would fail anyway, but with a slightly confusing
error message, e.g.:

```
evaluating jsonnet: RUNTIME ERROR: Attempt to use super when there is no super class.
```

Signed-off-by: Milan Plzik <milan.plzik@grafana.com>
